### PR TITLE
Bai 2 

### DIFF
--- a/2FirstWeeks/TimeConvertion/Program.cs
+++ b/2FirstWeeks/TimeConvertion/Program.cs
@@ -13,9 +13,9 @@ namespace TimeConvertion
         {
             string timeConversion(string s)
             {
-                var amOrPm = s.Substring(8);
-                var hour = s.Substring(0, 2);
-                var minuteSecond = s.Substring(2, 6);
+                var amOrPm = s.Substring(8);// sáng hay chiều
+                var hour = s.Substring(0, 2);//mấy giờ
+                var minuteSecond = s.Substring(2, 6);//phút giây
                 if (amOrPm == "AM" && hour == "12")
                 {
                     hour = "00";

--- a/2FirstWeeks/TimeConvertion/Program.cs
+++ b/2FirstWeeks/TimeConvertion/Program.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TimeConvertion
+{
+    internal class Program
+    {
+        
+        static void Main(string[] args)
+        {
+            string timeConversion(string s)
+            {
+                var amOrPm = s.Substring(8);
+                var hour = s.Substring(0, 2);
+                var minuteSecond = s.Substring(2, 6);
+                if (amOrPm == "AM" && hour == "12")
+                {
+                    hour = "00";
+                }
+                else if (amOrPm == "PM")
+                {
+                    var numericHourComponent = int.Parse(hour);
+                    if (numericHourComponent != 12)
+                    {
+                        hour = Convert.ToString(12 + numericHourComponent);
+                    }
+                }
+                return (hour + minuteSecond);
+            }
+            string gio = Console.ReadLine();
+
+            string result = timeConversion(gio);
+        }
+    }
+}


### PR DESCRIPTION
Given a time in [-hour AM/PM format](https://en.wikipedia.org/wiki/12-hour_clock), convert it to military (24-hour) time.

Note: - 12:00:00AM on a 12-hour clock is 00:00:00 on a 24-hour clock.
- 12:00:00PM on a 12-hour clock is 12:00:00 on a 24-hour clock.

Example

s="12:01:00"PM

Return '12:01:00'.

s="12:01:00"AM

Return '00:01:00'.

Function Description

Complete the timeConversion function in the editor below. It should return a new string representing the input time in 24 hour format.

timeConversion has the following parameter(s):

string s: a time in 12  hour format
Returns

string: the time in 24 hour format